### PR TITLE
Add additional domain for localhost:3000 to CORS_ALLOWED_ORIGINS

### DIFF
--- a/message_in_a_bottle/settings.py
+++ b/message_in_a_bottle/settings.py
@@ -56,6 +56,7 @@ MIDDLEWARE = [
 
 CORS_ALLOWED_ORIGINS = [
     # 'https://www.test-cors.org',
+    'http://localhost:3000',
     'https://message-in-a-bottle-fe-app.herokuapp.com',
 ]
 


### PR DESCRIPTION
- Changes Implemented:
  - Add `localhost:3000` as additional allowed domain for `CORS` testing

- Quality Control Checklist:

  - [x] >= 20% test coverage
  - [x] Last Commit passes CircleCI build


- Blockers (if applicable):

- Next Steps & Additional Notes: